### PR TITLE
Workaround for statistics memory leak

### DIFF
--- a/src/Kafka/Kafka.Client/Cfg/StatSettings.cs
+++ b/src/Kafka/Kafka.Client/Cfg/StatSettings.cs
@@ -1,0 +1,11 @@
+﻿namespace Kafka.Client.Cfg
+{
+    public static class StatSettings
+    {
+        public static volatile bool ConsumerStatsEnabled = false;
+
+        public static volatile bool ProducerStatsEnabled = false;
+
+        public static volatile bool FetcherThreadStatsEnabled = false;
+    }
+}

--- a/src/Kafka/Kafka.Client/Consumers/SimpleConsumer.cs
+++ b/src/Kafka/Kafka.Client/Consumers/SimpleConsumer.cs
@@ -1,4 +1,6 @@
-﻿namespace Kafka.Client.Consumers
+﻿using Kafka.Client.Cfg;
+
+namespace Kafka.Client.Consumers
 {
     using System;
     using System.Collections.Generic;
@@ -137,9 +139,22 @@
         internal FetchResponse Fetch(FetchRequest request)
         {
             Receive response = null;
-            var specificTimer = this.fetchRequestAndResponseStats.GetFetchRequestAndResponseStats(this.BrokerInfo).RequestTimer;
-            var aggregateTimer = this.fetchRequestAndResponseStats.GetFetchRequestAndResponseAllBrokersStats().RequestTimer;
-            aggregateTimer.Time(() => specificTimer.Time(() => { response = this.SendRequest(request); }));
+            if (StatSettings.ConsumerStatsEnabled)
+            {
+                var specificTimer =
+                    this.fetchRequestAndResponseStats.GetFetchRequestAndResponseStats(this.BrokerInfo).RequestTimer;
+                var aggregateTimer =
+                    this.fetchRequestAndResponseStats.GetFetchRequestAndResponseAllBrokersStats().RequestTimer;
+                aggregateTimer.Time(() => specificTimer.Time(() =>
+                {
+                    response = this.SendRequest(request);
+
+                }));
+            }
+            else
+            {
+                response = this.SendRequest(request);
+            }
 
             var fetchResponse = FetchResponse.ReadFrom(response.Buffer);
             var fetchedSize = fetchResponse.SizeInBytes;

--- a/src/Kafka/Kafka.Client/Kafka.Client.csproj
+++ b/src/Kafka/Kafka.Client/Kafka.Client.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Api\TopicMetadata.cs" />
     <Compile Include="Api\TopicMetadataRequest.cs" />
     <Compile Include="Api\TopicMetadataResponse.cs" />
+    <Compile Include="Cfg\StatSettings.cs" />
     <Compile Include="Common\Config.cs" />
     <Compile Include="Consumers\TopicEventHandler.cs" />
     <Compile Include="Extensions\DictionaryExtensions.cs" />


### PR DESCRIPTION
Original request from @kpocza; pulling into my fork to see how compatible this is with the latest Kafka release.

> Statistics for consumer, producer and fetcher thread is leaking memory.
> Added a switch as workaround for the problem. The statistics is off by
default.